### PR TITLE
Stateless redeploy nonce feasibility

### DIFF
--- a/STATELESS_REDEPLOY_NONCE_FEASIBILITY.md
+++ b/STATELESS_REDEPLOY_NONCE_FEASIBILITY.md
@@ -1,0 +1,159 @@
+# Feasibility Assessment: `statelessRedeployNonce`
+
+## Summary
+
+Adding a `statelessRedeployNonce` to the Flink Kubernetes Operator is **highly feasible** with **low-to-moderate complexity**. The existing codebase already has a well-established pattern for similar nonces that makes this a straightforward addition.
+
+## Existing Nonce Patterns in the Operator
+
+The operator already implements several nonces in `JobSpec` that serve as templates:
+
+1. **`restartNonce`** (in `AbstractFlinkSpec`) - Triggers restart following the current `upgradeMode` setting
+2. **`savepointRedeployNonce`** - Triggers full redeploy from `initialSavepointPath` 
+3. **`savepointTriggerNonce`** / **`checkpointTriggerNonce`** - Trigger snapshot operations (deprecated)
+4. **`autoscalerResetNonce`** - Resets autoscaler state
+
+## How the Existing Pattern Works
+
+### `savepointRedeployNonce` Implementation
+
+1. **Spec Definition** (`JobSpec.java:98-99`):
+   ```java
+   @SpecDiff(value = DiffType.SAVEPOINT_REDEPLOY, onNullIgnore = true)
+   private Long savepointRedeployNonce;
+   ```
+
+2. **Diff Detection**: When the nonce changes from the last reconciled spec, `ReflectiveDiffBuilder` detects this as a `DiffType.SAVEPOINT_REDEPLOY` change.
+
+3. **Reconciler Handling** (`AbstractJobReconciler.java:127-131`):
+   ```java
+   if (diffType == DiffType.SAVEPOINT_REDEPLOY) {
+       redeployWithSavepoint(ctx, deployConfig, resource, status, currentDeploySpec, desiredJobState);
+       return true;
+   }
+   ```
+
+4. **Redeployment Logic** (`AbstractJobReconciler.java:590-616`):
+   - Cancels the job with `SuspendMode.STATELESS`
+   - Sets upgrade mode to `UpgradeMode.SAVEPOINT`
+   - Deploys with the `initialSavepointPath`
+   - Marks spec as stable (disabling rollbacks)
+
+5. **Validation** (`DefaultValidator.java:448-457`):
+   - Validates that `initialSavepointPath` is not empty when nonce changes
+
+## Implementation Approach for `statelessRedeployNonce`
+
+### Option 1: New DiffType (Recommended)
+
+Add a new `DiffType.STATELESS_REDEPLOY` similar to `SAVEPOINT_REDEPLOY`:
+
+```java
+// DiffType.java
+public enum DiffType {
+    IGNORE,
+    SCALE,
+    UPGRADE,
+    SAVEPOINT_REDEPLOY,
+    STATELESS_REDEPLOY;  // NEW
+    // ...
+}
+```
+
+```java
+// JobSpec.java
+@SpecDiff(value = DiffType.STATELESS_REDEPLOY, onNullIgnore = true)
+private Long statelessRedeployNonce;
+```
+
+```java
+// AbstractJobReconciler.java
+if (diffType == DiffType.STATELESS_REDEPLOY) {
+    redeployStateless(ctx, deployConfig, resource, status, currentDeploySpec, desiredJobState);
+    return true;
+}
+
+private void redeployStateless(
+        FlinkResourceContext<CR> ctx,
+        Configuration deployConfig,
+        CR resource,
+        STATUS status,
+        SPEC currentDeploySpec,
+        JobState desiredJobState) throws Exception {
+    LOG.info("Redeploying statelessly");
+    cancelJob(ctx, SuspendMode.STATELESS);
+    currentDeploySpec.getJob().setUpgradeMode(UpgradeMode.STATELESS);
+    status.getJobStatus().setUpgradeSavepointPath(null);
+    
+    if (desiredJobState == JobState.RUNNING) {
+        deploy(ctx, currentDeploySpec, ctx.getDeployConfig(currentDeploySpec), Optional.empty(), false);
+    }
+    ReconciliationUtils.updateStatusForDeployedSpec(resource, deployConfig, clock);
+    status.getReconciliationStatus().markReconciledSpecAsStable();
+}
+```
+
+### Option 2: Reuse Existing Infrastructure
+
+Alternatively, leverage the existing `SAVEPOINT_REDEPLOY` flow with a flag:
+- Check if `statelessRedeployNonce` changed
+- If so, force `UpgradeMode.STATELESS` and null out `initialSavepointPath`
+- Reuse `redeployWithSavepoint` with empty path handling
+
+This is less clean but reduces code duplication.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `flink-kubernetes-operator-api/.../api/spec/JobSpec.java` | Add `statelessRedeployNonce` field with annotation |
+| `flink-kubernetes-operator-api/.../api/diff/DiffType.java` | Add `STATELESS_REDEPLOY` enum value |
+| `flink-kubernetes-operator/.../reconciler/deployment/AbstractJobReconciler.java` | Handle new diff type, add `redeployStateless()` method |
+| `flink-kubernetes-operator/.../reconciler/deployment/AbstractFlinkResourceReconciler.java` | Add `STATELESS_REDEPLOY` to scaling check condition |
+| `helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml` | Add `statelessRedeployNonce` field |
+| `helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml` | Add `statelessRedeployNonce` field |
+| `helm/flink-kubernetes-operator/crds/flinkbluegreendeployments.flink.apache.org-v1.yml` | Add `statelessRedeployNonce` field |
+| Tests | Add unit tests for new nonce handling |
+| Documentation | Update `job-management.md` and `reference.md` |
+
+## Complexity Assessment
+
+**Low-to-Moderate** (estimated 2-4 days for implementation + testing):
+
+- **Clear pattern to follow**: The `savepointRedeployNonce` provides an exact template
+- **Well-defined boundaries**: The reconciliation logic is modular
+- **No architectural changes**: Uses existing diff/reconcile infrastructure
+- **Main complexity**: Ensuring proper edge case handling (job in various states)
+
+## Key Behavioral Differences from `savepointRedeployNonce`
+
+| Aspect | `savepointRedeployNonce` | `statelessRedeployNonce` |
+|--------|--------------------------|--------------------------|
+| Requires `initialSavepointPath` | Yes (validated) | No |
+| Restores state | Yes, from specified savepoint | No, starts fresh |
+| Use case | Manual recovery | Fresh start, schema changes |
+
+## Potential Discussion Points for Open-Source Community
+
+1. **Naming Convention**: 
+   - `statelessRedeployNonce` - matches existing pattern
+   - `resetStateNonce` - more descriptive of what it does
+   - `freshStartNonce` - user-friendly
+
+2. **Warning/Confirmation Mechanism**: Should the operator emit a warning event when state is being dropped?
+
+3. **Rollback Behavior**: Like `savepointRedeployNonce`, rollbacks should be disabled after stateless redeploy (spec marked stable)
+
+4. **Interaction with `upgradeMode`**: Should this temporarily override the `upgradeMode` or permanently set it to stateless?
+
+5. **Concurrent Nonce Changes**: What happens if both `statelessRedeployNonce` and `savepointRedeployNonce` change? (Recommend: `STATELESS_REDEPLOY` takes precedence or validation error)
+
+## Recommendation
+
+This is a **clean, well-scoped feature** that aligns perfectly with existing operator patterns. The implementation is straightforward with clear precedent in the codebase. I recommend proceeding with a discussion with the open-source community, as this would be a valuable addition for use cases where a fresh start is needed without deleting and recreating the entire resource.
+
+The existing `savepointRedeployNonce` implementation can serve as almost a copy-paste template, with the main difference being:
+- No savepoint path validation
+- Use `SuspendMode.STATELESS` 
+- Deploy with `Optional.empty()` for savepoint
+- Set `UpgradeMode.STATELESS`


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request provides a detailed feasibility assessment for adding a new `statelessRedeployNonce` to the Flink Kubernetes Operator. This nonce would trigger a full redeployment of a Flink job without restoring state, similar to deploying with `upgradeMode: stateless`. The assessment aims to gauge the complexity of implementing this feature and provide context for potential discussions with the open-source community.

## Brief change log

- Added `STATELESS_REDEPLOY_NONCE_FEASIBILITY.md` which contains the comprehensive feasibility assessment.
- The assessment covers existing nonce patterns, a proposed implementation approach, a list of files that would need modification, a complexity assessment, and key discussion points for the open-source community.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---
[Slack Thread](https://shopify.slack.com/archives/C080V8HGJMB/p1768831267752839?thread_ts=1768831267.752839&cid=C080V8HGJMB)

<a href="https://cursor.com/background-agent?bcId=bc-815780bc-f025-4712-9f87-0c73fdfc4245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-815780bc-f025-4712-9f87-0c73fdfc4245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

