### PR TITLE
Fix observed generation

### DIFF
--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/FlinkBlueGreenDeploymentStatus.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/FlinkBlueGreenDeploymentStatus.java
@@ -38,6 +38,9 @@ public class FlinkBlueGreenDeploymentStatus {
 
     private JobStatus jobStatus = new JobStatus();
 
+    /** Last observed generation of the FlinkBlueGreenDeployment. */
+    private Long observedGeneration;
+
     /** The state of the blue/green transition. */
     private FlinkBlueGreenDeploymentState blueGreenState;
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
@@ -879,6 +879,8 @@ public class BlueGreenDeploymentService {
         }
 
         deploymentStatus.setLastReconciledTimestamp(java.time.Instant.now().toString());
+        deploymentStatus.setObservedGeneration(
+                flinkBlueGreenDeployment.getMetadata().getGeneration());
         flinkBlueGreenDeployment.setStatus(deploymentStatus);
         return UpdateControl.patchStatus(flinkBlueGreenDeployment);
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/handlers/InitializingBlueStateHandler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/handlers/InitializingBlueStateHandler.java
@@ -43,19 +43,24 @@ public class InitializingBlueStateHandler extends AbstractBlueGreenStateHandler 
     public UpdateControl<FlinkBlueGreenDeployment> handle(BlueGreenContext context) {
         FlinkBlueGreenDeploymentStatus deploymentStatus = context.getDeploymentStatus();
 
-        // Block initial deployment if job.state is SUSPENDED - user must start with RUNNING
+        // Block initial deployment if job.state is SUSPENDED - user must start with RUNNING.
+        // We still record the spec and update observedGeneration so external tools know the
+        // operator has processed this generation.
         var jobSpec = context.getBgDeployment().getSpec().getTemplate().getSpec().getJob();
         if (jobSpec != null && jobSpec.getState() == JobState.SUSPENDED) {
             LOG.info(
                     "Blocking initial deployment '{}' - job.state is SUSPENDED, waiting for RUNNING",
                     context.getBgDeployment().getMetadata().getName());
+            setLastReconciledSpec(context);
             return patchStatusUpdateControl(context, null, JobStatus.SUSPENDED, null);
         }
 
-        // Deploy only if this is the initial deployment (no previous spec exists)
-        // or if we're recovering from a failure and the spec has changed since the last attempt
+        // Deploy only if this is the initial deployment (no previous spec exists),
+        // recovering from a failure, or resuming from a suspended initial state
         if (deploymentStatus.getLastReconciledSpec() == null
                 || (deploymentStatus.getJobStatus().getState().equals(JobStatus.FAILING)
+                        && hasSpecChanged(context))
+                || (deploymentStatus.getJobStatus().getState().equals(JobStatus.SUSPENDED)
                         && hasSpecChanged(context))) {
 
             setLastReconciledSpec(context);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -109,8 +109,14 @@ public abstract class AbstractFlinkResourceReconciler<
         if (reconciliationStatus.isBeforeFirstDeployment()) {
             var spec = cr.getSpec();
 
-            // If the job is submitted in suspend state, no need to reconcile
+            // If the job is created in suspended state, acknowledge the spec without deploying.
+            // We must still update status (observedGeneration, lastReconciledSpec) so that
+            // external tools know the operator has processed this generation.
             if (spec.getJob() != null && spec.getJob().getState().equals(JobState.SUSPENDED)) {
+                LOG.info("Resource created in suspended state, acknowledging without deployment");
+                var deployConfig = ctx.getDeployConfig(spec);
+                ReconciliationUtils.updateStatusForDeployedSpec(cr, deployConfig, clock);
+                statusRecorder.patchAndCacheStatus(cr, ctx.getKubernetesClient());
                 return;
             }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -1343,6 +1343,46 @@ public class ApplicationReconcilerTest extends OperatorTestBase {
         assertEquals(2L, deployment.getStatus().getObservedGeneration());
     }
 
+    @Test
+    public void testSuspendedFirstDeploymentSetsObservedGeneration() throws Exception {
+        FlinkDeployment deployment = TestUtils.buildApplicationCluster();
+        deployment.getMetadata().setGeneration(1L);
+        deployment.getSpec().getJob().setState(JobState.SUSPENDED);
+
+        // Verify initial state: nothing has been reconciled yet
+        assertNull(deployment.getStatus().getObservedGeneration());
+        assertTrue(deployment.getStatus().getReconciliationStatus().isBeforeFirstDeployment());
+
+        // Reconcile the suspended deployment
+        reconciler.reconcile(deployment, context);
+
+        // observedGeneration must be set so external tools know we processed the spec
+        assertEquals(1L, deployment.getStatus().getObservedGeneration());
+
+        // lastReconciledSpec must be recorded so isBeforeFirstDeployment() returns false
+        assertFalse(deployment.getStatus().getReconciliationStatus().isBeforeFirstDeployment());
+        var lastReconciledSpec =
+                deployment.getStatus().getReconciliationStatus().deserializeLastReconciledSpec();
+        assertEquals(JobState.SUSPENDED, lastReconciledSpec.getJob().getState());
+
+        // State should be DEPLOYED and marked stable (suspended = stable by convention)
+        assertEquals(
+                ReconciliationState.DEPLOYED,
+                deployment.getStatus().getReconciliationStatus().getState());
+        assertTrue(deployment.getStatus().getReconciliationStatus().isLastReconciledSpecStable());
+
+        // No Flink cluster should have been created
+        assertEquals(0, flinkService.listJobs().size());
+
+        // Later: resuming the job should trigger a real deployment
+        deployment.getSpec().getJob().setState(JobState.RUNNING);
+        deployment.getMetadata().setGeneration(2L);
+        reconciler.reconcile(deployment, context);
+
+        assertEquals(1, flinkService.listJobs().size());
+        assertEquals(2L, deployment.getStatus().getObservedGeneration());
+    }
+
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void testRollbackUpgradeModeHandling(boolean jmStarted) throws Exception {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix observedGeneration not being set when a FlinkDeployment is created with spec.job.state: suspended. The operator returned early without updating any status fields, leaving observedGeneration null and causing deployment tools like kapp to hang indefinitely.

Additionally, add observedGeneration to FlinkBlueGreenDeploymentStatus which was missing entirely.


JIRA issue: https://issues.apache.org/jira/browse/FLINK-39243
Discussion: https://lists.apache.org/thread/4pk4v0wx901t4blsncx4j1jm8csc59z2

## Brief change log

- AbstractFlinkResourceReconciler: Update status before early return for suspended first deployments
- FlinkBlueGreenDeploymentStatus: Add observedGeneration field
- BlueGreenDeploymentService: Set observedGeneration on every status update
- InitializingBlueStateHandler: Record lastReconciledSpec for suspended state and add resume condition

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->
*(Please pick either of the following options)*

This change added tests and can be verified as follows:

Added testSuspendedFirstDeploymentSetsObservedGeneration in ApplicationReconcilerTest verifying observedGeneration is set, no resources are created, and resume to RUNNING works
