### PR TITLE
ObserveGeneration and lastStableGeneration for FlinkBlueGreenDeployment

### DIFF
--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -361,6 +361,8 @@ This serves as a full reference for FlinkDeployment and FlinkSessionJob custom r
 | ----------| ---- | ---- |
 | jobStatus | org.apache.flink.kubernetes.operator.api.status.JobStatus |  |
 | blueGreenState | org.apache.flink.kubernetes.operator.api.status.FlinkBlueGreenDeploymentState | The state of the blue/green transition. |
+| observedGeneration | java.lang.Long | Last observed generation of the FlinkBlueGreenDeployment. |
+| lastStableGeneration | java.lang.Long | Last generation that reached a stable terminal state. |
 | lastReconciledSpec | java.lang.String | Last reconciled (serialized) deployment spec. |
 | lastReconciledTimestamp | java.lang.String | Timestamp of last reconciliation. |
 | abortTimestamp | java.lang.String | Computed from abortGracePeriodMs, timestamp after which the deployment should be aborted. |

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/FlinkBlueGreenDeploymentStatus.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/FlinkBlueGreenDeploymentStatus.java
@@ -41,6 +41,12 @@ public class FlinkBlueGreenDeploymentStatus {
     /** The state of the blue/green transition. */
     private FlinkBlueGreenDeploymentState blueGreenState;
 
+    /** Last observed generation of the FlinkBlueGreenDeployment. */
+    private Long observedGeneration;
+
+    /** Last generation that reached a stable terminal state. */
+    private Long lastStableGeneration;
+
     /** Last reconciled (serialized) deployment spec. */
     private String lastReconciledSpec;
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentController.java
@@ -154,33 +154,59 @@ public class FlinkBlueGreenDeploymentController implements Reconciler<FlinkBlueG
 
             BlueGreenStateHandler handler = handlerRegistry.getHandler(currentState);
             UpdateControl<FlinkBlueGreenDeployment> updateControl = handler.handle(context);
-
-            var isActiveState = currentState == ACTIVE_BLUE || currentState == ACTIVE_GREEN;
-            var jobStatus = deploymentStatus.getJobStatus();
-            var jobState = jobStatus == null ? null : jobStatus.getState();
-            var isTerminalJobState =
-                    jobState == JobStatus.RUNNING
-                            || jobState == JobStatus.FINISHED
-                            || jobState == JobStatus.SUSPENDED;
-            if (updateControl.isNoUpdate()
-                    && (!BlueGreenDeploymentService.isGenerationObserved(context)
-                            || (isActiveState
-                                    && isTerminalJobState
-                                    && !BlueGreenDeploymentService.isGenerationStable(context)))) {
-                if (isActiveState && isTerminalJobState) {
-                    deploymentStatus.setLastStableGeneration(
-                            bgDeployment.getMetadata().getGeneration());
-                }
-                var statusUpdateControl =
-                        BlueGreenDeploymentService.patchStatusUpdateControl(
-                                context, null, null, null);
-                updateControl.getScheduleDelay().ifPresent(statusUpdateControl::rescheduleAfter);
-                updateControl = statusUpdateControl;
-            }
+            updateControl =
+                    syncGenerationStatusIfNeeded(
+                            bgDeployment, context, currentState, deploymentStatus, updateControl);
 
             statusRecorder.patchAndCacheStatus(bgDeployment, josdkContext.getClient());
             return updateControl;
         }
+    }
+
+    private static UpdateControl<FlinkBlueGreenDeployment> syncGenerationStatusIfNeeded(
+            FlinkBlueGreenDeployment bgDeployment,
+            BlueGreenContext context,
+            FlinkBlueGreenDeploymentState currentState,
+            FlinkBlueGreenDeploymentStatus deploymentStatus,
+            UpdateControl<FlinkBlueGreenDeployment> updateControl) {
+
+        // Migration/no-op path: kapp may reconcile an existing stable CR without rollout work when
+        // the rendered BlueGreen spec is unchanged, or when only non-spec resources/metadata
+        // changed. Handlers return noUpdate() in those cases, so sync generation status here.
+        if (updateControl.isNoUpdate()) {
+            var needsSync = !BlueGreenDeploymentService.isGenerationObserved(context);
+
+            if (!BlueGreenDeploymentService.isGenerationStable(context)
+                    && isStableBlueGreenJobStatus(currentState, deploymentStatus)) {
+                deploymentStatus.setLastStableGeneration(
+                        bgDeployment.getMetadata().getGeneration());
+                needsSync = true;
+            }
+
+            if (needsSync) {
+                var statusUpdateControl =
+                        BlueGreenDeploymentService.patchStatusUpdateControl(
+                                context, null, null, null);
+                updateControl.getScheduleDelay().ifPresent(statusUpdateControl::rescheduleAfter);
+                return statusUpdateControl;
+            }
+        }
+
+        return updateControl;
+    }
+
+    private static boolean isStableBlueGreenJobStatus(
+            FlinkBlueGreenDeploymentState currentState,
+            FlinkBlueGreenDeploymentStatus deploymentStatus) {
+        // Suspension is represented as ACTIVE_* with parent jobStatus SUSPENDED, not as a separate
+        // BlueGreen state. Transitional or failing states must continue waiting for finalization.
+        if (currentState != ACTIVE_BLUE && currentState != ACTIVE_GREEN) {
+            return false;
+        }
+
+        var jobStatus = deploymentStatus.getJobStatus();
+        var jobState = jobStatus == null ? null : jobStatus.getState();
+        return jobState == JobStatus.RUNNING || jobState == JobStatus.SUSPENDED;
     }
 
     public static void logAndThrow(String message) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentController.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.controller;
 
+import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.kubernetes.operator.api.FlinkBlueGreenDeployment;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.status.FlinkBlueGreenDeploymentState;
@@ -45,6 +46,8 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.flink.kubernetes.operator.api.status.FlinkBlueGreenDeploymentState.ACTIVE_BLUE;
+import static org.apache.flink.kubernetes.operator.api.status.FlinkBlueGreenDeploymentState.ACTIVE_GREEN;
 import static org.apache.flink.kubernetes.operator.api.status.FlinkBlueGreenDeploymentState.INITIALIZING_BLUE;
 
 /**
@@ -151,6 +154,30 @@ public class FlinkBlueGreenDeploymentController implements Reconciler<FlinkBlueG
 
             BlueGreenStateHandler handler = handlerRegistry.getHandler(currentState);
             UpdateControl<FlinkBlueGreenDeployment> updateControl = handler.handle(context);
+
+            var isActiveState = currentState == ACTIVE_BLUE || currentState == ACTIVE_GREEN;
+            var jobStatus = deploymentStatus.getJobStatus();
+            var jobState = jobStatus == null ? null : jobStatus.getState();
+            var isTerminalJobState =
+                    jobState == JobStatus.RUNNING
+                            || jobState == JobStatus.FINISHED
+                            || jobState == JobStatus.SUSPENDED;
+            if (updateControl.isNoUpdate()
+                    && (!BlueGreenDeploymentService.isGenerationObserved(context)
+                            || (isActiveState
+                                    && isTerminalJobState
+                                    && !BlueGreenDeploymentService.isGenerationStable(context)))) {
+                if (isActiveState && isTerminalJobState) {
+                    deploymentStatus.setLastStableGeneration(
+                            bgDeployment.getMetadata().getGeneration());
+                }
+                var statusUpdateControl =
+                        BlueGreenDeploymentService.patchStatusUpdateControl(
+                                context, null, null, null);
+                updateControl.getScheduleDelay().ifPresent(statusUpdateControl::rescheduleAfter);
+                updateControl = statusUpdateControl;
+            }
+
             statusRecorder.patchAndCacheStatus(bgDeployment, josdkContext.getClient());
             return updateControl;
         }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
@@ -859,6 +859,18 @@ public class BlueGreenDeploymentService {
         status.setSavepointTriggerId(null);
     }
 
+    public static boolean isGenerationObserved(BlueGreenContext context) {
+        return Objects.equals(
+                context.getDeploymentStatus().getObservedGeneration(),
+                context.getBgDeployment().getMetadata().getGeneration());
+    }
+
+    public static boolean isGenerationStable(BlueGreenContext context) {
+        return Objects.equals(
+                context.getDeploymentStatus().getLastStableGeneration(),
+                context.getBgDeployment().getMetadata().getGeneration());
+    }
+
     public static UpdateControl<FlinkBlueGreenDeployment> patchStatusUpdateControl(
             BlueGreenContext context,
             FlinkBlueGreenDeploymentState deploymentState,
@@ -884,6 +896,13 @@ public class BlueGreenDeploymentService {
             deploymentStatus.setError(null);
         }
 
+        if (jobState == JobStatus.RUNNING || jobState == JobStatus.SUSPENDED) {
+            deploymentStatus.setLastStableGeneration(
+                    flinkBlueGreenDeployment.getMetadata().getGeneration());
+        }
+
+        deploymentStatus.setObservedGeneration(
+                flinkBlueGreenDeployment.getMetadata().getGeneration());
         deploymentStatus.setLastReconciledTimestamp(java.time.Instant.now().toString());
         flinkBlueGreenDeployment.setStatus(deploymentStatus);
         return UpdateControl.patchStatus(flinkBlueGreenDeployment);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
@@ -52,6 +52,7 @@ import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -126,6 +127,118 @@ public class FlinkBlueGreenDeploymentControllerTest {
                         initialSavepointPath,
                         UpgradeMode.STATELESS);
         executeBasicDeployment(flinkVersion, blueGreenDeployment, true, initialSavepointPath);
+    }
+
+    @Test
+    public void verifyObservedGenerationUpdatedWhenNewSpecObserved() throws Exception {
+        var blueGreenDeployment =
+                buildSessionCluster(
+                        TEST_DEPLOYMENT_NAME,
+                        TEST_NAMESPACE,
+                        FlinkVersion.v1_20,
+                        null,
+                        UpgradeMode.STATELESS);
+        var rs = executeBasicDeployment(FlinkVersion.v1_20, blueGreenDeployment, false, null);
+
+        Long previousGeneration = rs.deployment.getMetadata().getGeneration();
+        assertNotNull(previousGeneration);
+        assertEquals(previousGeneration, rs.reconciledStatus.getObservedGeneration());
+        assertEquals(previousGeneration, rs.reconciledStatus.getLastStableGeneration());
+
+        simulateSpecChange(rs.deployment, UUID.randomUUID().toString());
+        Long newGeneration = previousGeneration + 1;
+        rs.deployment.getMetadata().setGeneration(newGeneration);
+        kubernetesClient.resource(rs.deployment).createOrReplace();
+
+        rs = reconcile(rs.deployment);
+
+        assertEquals(newGeneration, rs.reconciledStatus.getObservedGeneration());
+        assertEquals(previousGeneration, rs.reconciledStatus.getLastStableGeneration());
+        assertEquals(
+                FlinkBlueGreenDeploymentState.TRANSITIONING_TO_GREEN,
+                rs.reconciledStatus.getBlueGreenState());
+        assertEquals(JobStatus.RECONCILING, rs.reconciledStatus.getJobStatus().getState());
+    }
+
+    @Test
+    public void verifyObservedGenerationBackfilledForExistingStatus() throws Exception {
+        var blueGreenDeployment =
+                buildSessionCluster(
+                        TEST_DEPLOYMENT_NAME,
+                        TEST_NAMESPACE,
+                        FlinkVersion.v1_20,
+                        null,
+                        UpgradeMode.STATELESS);
+        var rs = executeBasicDeployment(FlinkVersion.v1_20, blueGreenDeployment, false, null);
+
+        rs.deployment.getStatus().setObservedGeneration(null);
+        rs.deployment.getStatus().setLastStableGeneration(null);
+
+        rs = reconcile(rs.deployment);
+
+        assertTrue(rs.updateControl.isPatchStatus());
+        assertEquals(
+                rs.deployment.getMetadata().getGeneration(),
+                rs.reconciledStatus.getObservedGeneration());
+        assertEquals(
+                rs.deployment.getMetadata().getGeneration(),
+                rs.reconciledStatus.getLastStableGeneration());
+        assertEquals(
+                FlinkBlueGreenDeploymentState.ACTIVE_BLUE, rs.reconciledStatus.getBlueGreenState());
+        assertEquals(JobStatus.RUNNING, rs.reconciledStatus.getJobStatus().getState());
+    }
+
+    @Test
+    public void verifyStableGenerationNotUpdatedWhenTransitionFailsBeforeStart() throws Exception {
+        var blueGreenDeployment =
+                buildSessionCluster(
+                        TEST_DEPLOYMENT_NAME,
+                        TEST_NAMESPACE,
+                        FlinkVersion.v1_20,
+                        null,
+                        UpgradeMode.STATELESS);
+        var rs = executeBasicDeployment(FlinkVersion.v1_20, blueGreenDeployment, false, null);
+
+        Long previousGeneration = rs.deployment.getMetadata().getGeneration();
+        simulateSpecChange(rs.deployment, UUID.randomUUID().toString());
+        Long newGeneration = previousGeneration + 1;
+        rs.deployment.getMetadata().setGeneration(newGeneration);
+        kubernetesClient.resource(rs.deployment).createOrReplace();
+        simulateJobFailure(getFlinkDeployments().get(0));
+
+        rs = reconcile(rs.deployment);
+
+        assertEquals(newGeneration, rs.reconciledStatus.getObservedGeneration());
+        assertEquals(previousGeneration, rs.reconciledStatus.getLastStableGeneration());
+        assertEquals(JobStatus.FAILING, rs.reconciledStatus.getJobStatus().getState());
+        assertEquals(
+                FlinkBlueGreenDeploymentState.ACTIVE_BLUE, rs.reconciledStatus.getBlueGreenState());
+    }
+
+    @Test
+    public void verifyStableGenerationNotUpdatedDuringSavepointHandoff() throws Exception {
+        var blueGreenDeployment =
+                buildSessionCluster(
+                        TEST_DEPLOYMENT_NAME,
+                        TEST_NAMESPACE,
+                        FlinkVersion.v1_20,
+                        null,
+                        UpgradeMode.SAVEPOINT);
+        var rs = executeBasicDeployment(FlinkVersion.v1_20, blueGreenDeployment, false, null);
+
+        Long previousGeneration = rs.deployment.getMetadata().getGeneration();
+        simulateSpecChange(rs.deployment, UUID.randomUUID().toString());
+        Long newGeneration = previousGeneration + 1;
+        rs.deployment.getMetadata().setGeneration(newGeneration);
+        kubernetesClient.resource(rs.deployment).createOrReplace();
+
+        rs = handleSavepoint(rs);
+
+        assertEquals(newGeneration, rs.reconciledStatus.getObservedGeneration());
+        assertEquals(previousGeneration, rs.reconciledStatus.getLastStableGeneration());
+        assertEquals(
+                FlinkBlueGreenDeploymentState.ACTIVE_BLUE, rs.reconciledStatus.getBlueGreenState());
+        assertEquals(JobStatus.RUNNING, rs.reconciledStatus.getJobStatus().getState());
     }
 
     @ParameterizedTest
@@ -1181,6 +1294,12 @@ public class FlinkBlueGreenDeploymentControllerTest {
                 JobStatus.SUSPENDED,
                 rs.reconciledStatus.getJobStatus().getState(),
                 "Job status should be SUSPENDED when initial deployment is blocked");
+        assertEquals(
+                rs.deployment.getMetadata().getGeneration(),
+                rs.reconciledStatus.getObservedGeneration());
+        assertEquals(
+                rs.deployment.getMetadata().getGeneration(),
+                rs.reconciledStatus.getLastStableGeneration());
 
         // Flip to RUNNING and reconcile again
         bg = rs.deployment;
@@ -1507,6 +1626,12 @@ public class FlinkBlueGreenDeploymentControllerTest {
                 rs.reconciledStatus.getLastReconciledSpec());
         assertEquals(expectedBGDeploymentState, rs.reconciledStatus.getBlueGreenState());
         assertEquals(JobStatus.RUNNING, rs.reconciledStatus.getJobStatus().getState());
+        assertEquals(
+                rs.deployment.getMetadata().getGeneration(),
+                rs.reconciledStatus.getObservedGeneration());
+        assertEquals(
+                rs.deployment.getMetadata().getGeneration(),
+                rs.reconciledStatus.getLastStableGeneration());
         assertEquals(0, instantStrToMillis(rs.reconciledStatus.getDeploymentReadyTimestamp()));
         assertEquals(0, instantStrToMillis(rs.reconciledStatus.getAbortTimestamp()));
 
@@ -1796,6 +1921,7 @@ public class FlinkBlueGreenDeploymentControllerTest {
                         .withCreationTimestamp(Instant.now().toString())
                         .withUid(UUID.randomUUID().toString())
                         .withResourceVersion("1")
+                        .withGeneration(1L)
                         .build());
         var bgDeploymentSpec = getTestFlinkDeploymentSpec(version);
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
@@ -161,7 +161,7 @@ public class FlinkBlueGreenDeploymentControllerTest {
     }
 
     @Test
-    public void verifyObservedGenerationBackfilledForExistingStatus() throws Exception {
+    public void verifyGenerationStatusSyncedForExistingStableStatus() throws Exception {
         var blueGreenDeployment =
                 buildSessionCluster(
                         TEST_DEPLOYMENT_NAME,

--- a/helm/flink-kubernetes-operator/crds/flinkbluegreendeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkbluegreendeployments.flink.apache.org-v1.yml
@@ -10938,6 +10938,10 @@ spec:
                 type: "string"
               lastReconciledTimestamp:
                 type: "string"
+              lastStableGeneration:
+                type: "integer"
+              observedGeneration:
+                type: "integer"
               savepointTriggerId:
                 type: "string"
             type: "object"


### PR DESCRIPTION
### What is the purpose of the change                                                                              
                                                                                                                
 This pull request makes FlinkBlueGreenDeployment status generation-aware so external deploy tooling can        
 distinguish stale parent status from status that belongs to the currently applied spec generation.             
                                                                                                                
 Before this change, a BlueGreen parent could still report ACTIVE_BLUE / ACTIVE_GREEN and RUNNING from the      
 previous generation after Kubernetes had already accepted a new spec/image. This could allow kapp to mark a    
 deploy successful before the new BlueGreen generation had actually completed, especially around savepoint      
 handoff where the parent can temporarily return to ACTIVE_* / RUNNING before the new color is live.            
                                                                                                                
 The change adds two parent status fields with separate semantics:                                              
                                                                                                                
 - observedGeneration: the latest metadata.generation observed by the operator.                                 
 - lastStableGeneration: the latest metadata.generation that reached a stable BlueGreen terminal state.         
                                                                                                                
 observedGeneration provides the standard Kubernetes freshness signal used by kapp’s supportsObservedGeneration 
  behavior. lastStableGeneration provides the BlueGreen-specific completion signal needed because ACTIVE_* /    
 RUNNING alone is not always proof that the current parent generation is complete.                              
                                                                                                                
 ### Brief change log                                                                                               
                                                                                                                
 - Added status.observedGeneration to FlinkBlueGreenDeploymentStatus.                                           
 - Added status.lastStableGeneration to FlinkBlueGreenDeploymentStatus.                                         
 - Updated the BlueGreen CRD schema and generated custom-resource reference docs.                               
 - Centralized generation stamping in BlueGreenDeploymentService.patchStatusUpdateControl(...).                 
     - Every status patch records observedGeneration = metadata.generation.                                     
     - lastStableGeneration advances only when the parent status is written as stable terminal status (RUNNING  
       or SUSPENDED).                                                                                           
 - Added controller no-op backfill for existing stable BlueGreen resources missing the new fields.              
 - Added tests covering stale generation, stable generation, savepoint handoff, failure, existing-resource      
   backfill, initial suspended deploys, and final active stability.                                             
                                                                                                                
 ### Verifying this change                                                                                          
                                                                                                                
This change added tests and can be verified as follows:                                                        
                                                                                                                
 - Added focused controller tests for:                                                                          
     - observedGeneration updating when a new spec generation is observed.                                      
     - Existing stable resources backfilling missing generation status fields.                                  
     - lastStableGeneration not advancing when a transition fails before start.                                 
     - lastStableGeneration not advancing during savepoint handoff while parent status is ACTIVE_* / RUNNING.   
     - Initial suspended BlueGreen deploys being marked stable for the current generation.                      
     - Final active BlueGreen deployments being marked stable for the current generation.                       
                                                                                                                
 Verified locally with:                                                                                         
                                                                                                                
 ```bash                                                                                                        
   mvn -pl flink-kubernetes-operator -am \                                                                      
     -DskipITs -DskipE2E -DskipRat \                                                                            
     -Dcheckstyle.skip -Dspotless.check.skip=true -Dspotless.apply.skip=true \                                  
     -DfailIfNoTests=false \                                                                                    
     -Dtest=FlinkBlueGreenDeploymentControllerTest test                                                         
 ```                                                                                                            
                                                                                                                
 Result:                                                                                                        
                                                                                                                
 ```text                                                                                                        
   Tests run: 76, Failures: 0, Errors: 0, Skipped: 0                                                            
 ```                                                                                                            
                                                                                                                
 Also verified formatting with Spotless check for the touched module.                                           
                                                                                                                
 ###Does this pull request potentially affect one of the following parts:                                          
                                                                                                                
 - Dependencies (does it add or upgrade a dependency): no                                                       
 - The public API, i.e., is any changes to the CustomResourceDescriptors: yes                                   
 - Core observer or reconciler logic that is regularly executed: yes                                            
                                                                                                                
### Documentation                                                                                                  
                                                                                                                
 - Does this pull request introduce a new feature? yes                                                          
 - If yes, how is the feature documented? docs   