### PR TITLE
[FLINK-39958] Honor per-deployment Flink REST client timeout on rescale

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkResourceContext.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkResourceContext.java
@@ -68,9 +68,11 @@ public abstract class FlinkResourceContext<CR extends AbstractFlinkResource<?, ?
 
     private KubernetesJobAutoScalerContext createJobAutoScalerContext() {
         Configuration conf = new Configuration(getDeployConfig(resource.getSpec()));
-        conf.set(
-                AutoScalerOptions.FLINK_CLIENT_TIMEOUT,
-                getOperatorConfig().getFlinkClientTimeout());
+        if (!conf.contains(AutoScalerOptions.FLINK_CLIENT_TIMEOUT)) {
+            conf.set(
+                    AutoScalerOptions.FLINK_CLIENT_TIMEOUT,
+                    getOperatorConfig().getFlinkClientTimeout());
+        }
 
         CommonStatus<?> status = getResource().getStatus();
         String jobId = status.getJobStatus().getJobId();

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes.operator.service;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.client.cli.ApplicationDeployer;
 import org.apache.flink.client.deployment.ClusterClientFactory;
 import org.apache.flink.client.deployment.ClusterClientServiceLoader;
@@ -187,8 +188,11 @@ public class NativeFlinkService extends AbstractFlinkService {
             return false;
         }
 
+        var restClientTimeout = getRescaleRestClientTimeout(observeConfig);
+
         try (var client = getClusterClient(observeConfig)) {
-            var requirements = new HashMap<>(getVertexResources(client, resource));
+            var requirements =
+                    new HashMap<>(getVertexResources(client, resource, restClientTimeout));
             var alreadyScaled = true;
 
             for (Map.Entry<JobVertexID, JobVertexResourceRequirements> entry :
@@ -224,7 +228,7 @@ public class NativeFlinkService extends AbstractFlinkService {
             if (alreadyScaled) {
                 LOG.info("Vertex resources requirements already match target, nothing to do...");
             } else {
-                updateVertexResources(client, resource, requirements);
+                updateVertexResources(client, resource, restClientTimeout, requirements);
                 eventRecorder.triggerEvent(
                         resource,
                         EventRecorder.Type.Normal,
@@ -269,10 +273,26 @@ public class NativeFlinkService extends AbstractFlinkService {
         return true;
     }
 
+    /**
+     * Timeout for the resource requirement REST calls made against the running JobManager during
+     * in-place scaling. Deployments may raise it through {@link
+     * AutoScalerOptions#FLINK_CLIENT_TIMEOUT}, otherwise the operator-global {@code
+     * kubernetes.operator.flink.client.timeout} is used as before.
+     *
+     * @param conf Config of the deployment being rescaled.
+     * @return Timeout to apply to the in-place scaling REST calls.
+     */
+    @VisibleForTesting
+    protected Duration getRescaleRestClientTimeout(Configuration conf) {
+        return conf.getOptional(AutoScalerOptions.FLINK_CLIENT_TIMEOUT)
+                .orElseGet(operatorConfig::getFlinkClientTimeout);
+    }
+
     @VisibleForTesting
     protected void updateVertexResources(
             RestClusterClient<String> client,
             AbstractFlinkResource<?, ?> resource,
+            Duration restClientTimeout,
             Map<JobVertexID, JobVertexResourceRequirements> newReqs)
             throws Exception {
         var jobParameters = new JobMessageParameters();
@@ -282,12 +302,14 @@ public class NativeFlinkService extends AbstractFlinkService {
         var requestBody = new JobResourceRequirementsBody(new JobResourceRequirements(newReqs));
 
         client.sendRequest(new JobResourcesRequirementsUpdateHeaders(), jobParameters, requestBody)
-                .get(operatorConfig.getFlinkClientTimeout().toSeconds(), TimeUnit.SECONDS);
+                .get(restClientTimeout.toSeconds(), TimeUnit.SECONDS);
     }
 
     @VisibleForTesting
     protected Map<JobVertexID, JobVertexResourceRequirements> getVertexResources(
-            RestClusterClient<String> client, AbstractFlinkResource<?, ?> resource)
+            RestClusterClient<String> client,
+            AbstractFlinkResource<?, ?> resource,
+            Duration restClientTimeout)
             throws Exception {
         var jobParameters = new JobMessageParameters();
         jobParameters.jobPathParameter.resolve(
@@ -298,7 +320,7 @@ public class NativeFlinkService extends AbstractFlinkService {
                                 new JobResourceRequirementsHeaders(),
                                 jobParameters,
                                 EmptyRequestBody.getInstance())
-                        .get(operatorConfig.getFlinkClientTimeout().toSeconds(), TimeUnit.SECONDS);
+                        .get(restClientTimeout.toSeconds(), TimeUnit.SECONDS);
 
         return currentRequirements.asJobResourceRequirements().get().getJobVertexParallelisms();
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkResourceContextTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkResourceContextTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.controller;
 
+import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
@@ -148,6 +149,45 @@ public class FlinkResourceContextTest {
         assertTrue(sessionJobCtx.getObserveConfig() == conf);
         assertTrue(sessionJobCtx.getObserveConfig() == conf);
         assertEquals(2, counter.get());
+    }
+
+    @Test
+    void testAutoscalerFlinkClientTimeoutDefaultsToOperatorTimeout() {
+        var conf = new Configuration();
+        conf.set(
+                KubernetesOperatorConfigOptions.OPERATOR_FLINK_CLIENT_TIMEOUT,
+                Duration.ofSeconds(60));
+        configManager = new FlinkConfigManager(conf);
+
+        // No explicit autoscaler client timeout -> falls back to the operator timeout.
+        var ctx = getContext(TestUtils.buildApplicationCluster());
+        assertEquals(
+                Duration.ofSeconds(60),
+                ctx.getJobAutoScalerContext()
+                        .getConfiguration()
+                        .get(AutoScalerOptions.FLINK_CLIENT_TIMEOUT));
+    }
+
+    @Test
+    void testExplicitAutoscalerFlinkClientTimeoutIsRespected() {
+        var conf = new Configuration();
+        conf.set(
+                KubernetesOperatorConfigOptions.OPERATOR_FLINK_CLIENT_TIMEOUT,
+                Duration.ofSeconds(60));
+        configManager = new FlinkConfigManager(conf);
+
+        var dep = TestUtils.buildApplicationCluster();
+        dep.getSpec()
+                .getFlinkConfiguration()
+                .put(AutoScalerOptions.FLINK_CLIENT_TIMEOUT.key(), "30 s");
+
+        // An explicit autoscaler timeout must not be silently overridden by the operator timeout.
+        var ctx = getContext(dep);
+        assertEquals(
+                Duration.ofSeconds(30),
+                ctx.getJobAutoScalerContext()
+                        .getConfiguration()
+                        .get(AutoScalerOptions.FLINK_CLIENT_TIMEOUT));
     }
 
     FlinkResourceContext getContext(AbstractFlinkResource<?, ?> cr) {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -892,7 +892,9 @@ public class ApplicationReconcilerTest extends OperatorTestBase {
 
                     @Override
                     protected Map<JobVertexID, JobVertexResourceRequirements> getVertexResources(
-                            RestClusterClient<String> c, AbstractFlinkResource<?, ?> r) {
+                            RestClusterClient<String> c,
+                            AbstractFlinkResource<?, ?> r,
+                            Duration restClientTimeout) {
                         return submitted;
                     }
 
@@ -900,6 +902,7 @@ public class ApplicationReconcilerTest extends OperatorTestBase {
                     protected void updateVertexResources(
                             RestClusterClient<String> c,
                             AbstractFlinkResource<?, ?> r,
+                            Duration restClientTimeout,
                             Map<JobVertexID, JobVertexResourceRequirements> req) {
                         submitted = req;
                         rescaleCounter.incrementAndGet();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/NativeFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/NativeFlinkServiceTest.java
@@ -19,6 +19,7 @@ package org.apache.flink.kubernetes.operator.service;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
@@ -260,7 +261,8 @@ public class NativeFlinkServiceTest {
                     @Override
                     protected Map<JobVertexID, JobVertexResourceRequirements> getVertexResources(
                             RestClusterClient<String> client,
-                            AbstractFlinkResource<?, ?> resource) {
+                            AbstractFlinkResource<?, ?> resource,
+                            Duration restClientTimeout) {
                         return current.get();
                     }
 
@@ -268,6 +270,7 @@ public class NativeFlinkServiceTest {
                     protected void updateVertexResources(
                             RestClusterClient<String> client,
                             AbstractFlinkResource<?, ?> resource,
+                            Duration restClientTimeout,
                             Map<JobVertexID, JobVertexResourceRequirements> newReqs) {
                         updated.set(newReqs);
                     }
@@ -552,11 +555,45 @@ public class NativeFlinkServiceTest {
 
         var deployment = TestUtils.buildApplicationCluster();
         deployment.getStatus().getJobStatus().setJobId(jobId.toString());
+        var restClientTimeout = service.getRescaleRestClientTimeout(configuration);
         assertEquals(
                 reqs.getJobVertexParallelisms(),
-                service.getVertexResources(testingClusterClient, deployment));
+                service.getVertexResources(testingClusterClient, deployment, restClientTimeout));
         service.updateVertexResources(
-                testingClusterClient, deployment, reqs.getJobVertexParallelisms());
+                testingClusterClient,
+                deployment,
+                restClientTimeout,
+                reqs.getJobVertexParallelisms());
+    }
+
+    @Test
+    public void testRescaleRestClientTimeoutFallsBackToOperatorTimeout() {
+        var service = createServiceWithOperatorClientTimeout(Duration.ofSeconds(60));
+
+        // Key unset -> the operator-global timeout keeps governing the rescale REST calls.
+        assertEquals(
+                Duration.ofSeconds(60), service.getRescaleRestClientTimeout(new Configuration()));
+    }
+
+    @Test
+    public void testRescaleRestClientTimeoutHonoursDeploymentOverride() {
+        var service = createServiceWithOperatorClientTimeout(Duration.ofSeconds(60));
+
+        var deployConf = new Configuration();
+        deployConf.set(AutoScalerOptions.FLINK_CLIENT_TIMEOUT, Duration.ofSeconds(30));
+
+        // Key explicitly set -> the deployment value wins over the operator-global timeout.
+        assertEquals(Duration.ofSeconds(30), service.getRescaleRestClientTimeout(deployConf));
+    }
+
+    private NativeFlinkService createServiceWithOperatorClientTimeout(Duration timeout) {
+        configuration.set(KubernetesOperatorConfigOptions.OPERATOR_FLINK_CLIENT_TIMEOUT, timeout);
+        return new NativeFlinkService(
+                client,
+                null,
+                executorService,
+                FlinkOperatorConfiguration.fromConfiguration(configuration),
+                eventRecorder);
     }
 
     class TestingNativeFlinkService extends NativeFlinkService {


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/FLINK-39958
Requested by: Pierre-Olivier Bédard <pierre.bedard@shopify.com>
Slack thread: https://shopify.slack.com/archives/C0AKLLE8GPJ/p1785358236166909

## What

- Cherry-pick FLINK-39958 (apache/flink-kubernetes-operator#1141): `FlinkResourceContext` now only seeds `AutoScalerOptions.FLINK_CLIENT_TIMEOUT` from the operator-global timeout when the deployment has not set it.
- Extend the same honor-the-per-deployment-value rule to the in-place rescale REST calls in `NativeFlinkService`, which read `operatorConfig` directly and are therefore untouched by FLINK-39958.
- No default changes. With `job.autoscaler.flink.rest-client.timeout` unset, both paths resolve to the operator-global timeout exactly as before.

## Why

`kubernetes.operator.flink.client.timeout` (default 10s) is the budget for the `PUT /jobs/<id>/resource-requirements` call the operator makes against a running JobManager. It is operator-global — read from `FlinkOperatorConfiguration`, built by `FlinkConfigManager.getDefaultConfig` from the operator's own configuration — so a pipeline owner cannot raise it from their `FlinkDeployment` spec, and the per-deployment-looking `job.autoscaler.flink.rest-client.timeout` is silently clobbered.

When that call times out, the operator abandons in-place scaling with no retry and falls back to a full savepoint-and-redeploy: suspend with savepoint, delete the JobManager deployment, delete HA metadata, redeploy. On `webhooks-production-java-change-event-producer` that turns a ~3s rescale into ~150s of no checkpoint progress plus a slow-recovery tail. It fired 7 times in 24h on that pipeline, 17 times fleet-wide across three pipelines.

Raising the tolerance is the lever rather than more JobManager capacity: JM process CPU sat at 7-18% of its one core throughout, and the call blocks behind the adaptive scheduler's main thread while it rebuilds the execution graph and registers newly requested TaskManagers.

## Details

- Change 1 is merged upstream. Change 2 is a new local change and should also be proposed to Apache so the fork can drop it later.
- Change 2 covers `getVertexResources` as well as `updateVertexResources`. Both are REST calls inside the same `scale()` try block, both were pinned to the operator-global timeout, and both surface as the same `Error while rescaling, falling back to regular upgrade`. `getVertexResources` runs first, so leaving it at 10s would keep the teardown path open. Happy to narrow this to `updateVertexResources` only if you prefer the smaller surface.
- `mvn verify -pl flink-kubernetes-operator`: 2113 tests pass, 0 Checkstyle violations, spotless clean.
