### PR TITLE
Don't trust busy-time TPR on near-idle vertices

### DIFF
--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -243,6 +243,12 @@
             <td>A (semicolon-separated) list of vertex ids in hexstring for which to disable scaling. Caution: For non-sink vertices this will still scale their downstream operators until https://issues.apache.org/jira/browse/FLINK-31215 is implemented.</td>
         </tr>
         <tr>
+            <td><h5>job.autoscaler.vertex.idle-input-rate-threshold</h5></td>
+            <td style="word-wrap: break-word;">0.01</td>
+            <td>Double</td>
+            <td>Per-subtask input rate, in records per second averaged over the metric window, below which a vertex is treated as idle and its busy time based true processing rate is not trusted. Below this rate there are too few records per subtask to estimate a processing rate, while the aggregated busy time can still read close to saturated (with the default MAX aggregator a single briefly-busy subtask reports for the whole vertex). That combination makes the scale factor saturate the scale-up and scale-down clamps on alternating evaluations, so the vertex oscillates between min and max parallelism. Such vertices are treated the same as ones with an input rate of exactly zero. Set to 0 to restore the previous behaviour of only special-casing an exactly-zero rate.</td>
+        </tr>
+        <tr>
             <td><h5>job.autoscaler.vertex.max-parallelism</h5></td>
             <td style="word-wrap: break-word;">200</td>
             <td>Integer</td>

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
@@ -158,7 +158,12 @@ public class ScalingMetricEvaluator {
                 TRUE_PROCESSING_RATE,
                 EvaluatedScalingMetric.avg(
                         computeTrueProcessingRate(
-                                busyTimeAvg, inputRateAvg, metricsHistory, vertex, conf)));
+                                busyTimeAvg,
+                                inputRateAvg,
+                                metricsHistory,
+                                vertex,
+                                conf,
+                                vertexInfo.getParallelism())));
 
         evaluatedMetrics.put(LOAD, EvaluatedScalingMetric.avg(busyTimeAvg / 1000.));
 
@@ -218,6 +223,7 @@ public class ScalingMetricEvaluator {
      * @param metricsHistory
      * @param vertex
      * @param conf
+     * @param parallelism
      * @return Average true processing rate over metric window.
      */
     protected static double computeTrueProcessingRate(
@@ -225,9 +231,15 @@ public class ScalingMetricEvaluator {
             double inputRateAvg,
             SortedMap<Instant, CollectedMetrics> metricsHistory,
             JobVertexID vertex,
-            Configuration conf) {
+            Configuration conf,
+            int parallelism) {
 
-        var busyTimeTpr = computeTprFromBusyTime(busyTimeAvg, inputRateAvg);
+        var busyTimeTpr =
+                computeTprFromBusyTime(
+                        busyTimeAvg,
+                        inputRateAvg,
+                        parallelism,
+                        conf.get(AutoScalerOptions.VERTEX_IDLE_INPUT_RATE_THRESHOLD));
         var observedTprAvg =
                 getAverage(
                         OBSERVED_TPR,
@@ -239,10 +251,28 @@ public class ScalingMetricEvaluator {
         return tprMetric == OBSERVED_TPR ? observedTprAvg : busyTimeTpr;
     }
 
-    private static double computeTprFromBusyTime(double busyMsPerSecond, double rate) {
+    private static double computeTprFromBusyTime(
+            double busyMsPerSecond, double rate, int parallelism, double idleInputRateThreshold) {
         if (rate == 0) {
             // Nothing is coming in, we assume infinite processing power
             // until we can sample the true processing rate (i.e. data flows).
+            return Double.POSITIVE_INFINITY;
+        }
+        if (parallelism > 0 && rate / parallelism < idleInputRateThreshold) {
+            // Next to nothing is coming in, but not exactly nothing, so the guard above does not
+            // catch it. busyMsPerSecond can still read close to saturated here: with the default
+            // MAX aggregator a single briefly-busy subtask reports for the whole vertex, so on a
+            // wide and almost idle vertex the aggregated busy time approaches 1000 ms/s while
+            // nearly every subtask is doing nothing. rate / busyTime is then a ratio of two
+            // noise-floor numbers, and the resulting scale factor saturates the scale-up and
+            // scale-down clamps on alternating evaluations, so the vertex oscillates between min
+            // and max parallelism indefinitely instead of converging.
+            //
+            // Below the threshold there are too few records per subtask in a metric window to
+            // estimate a processing rate at all, so treat the vertex as idle exactly as we do
+            // when the rate is precisely zero. If the vertex is in fact backlogged, OBSERVED_TPR
+            // is measured during catch-up and selectTprMetric prefers it over an infinite
+            // busy-time TPR, so genuine scale-ups are still driven by the observed rate.
             return Double.POSITIVE_INFINITY;
         }
         return rate / (busyMsPerSecond / 1000);

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -332,6 +332,14 @@ public class AutoScalerOptions {
                     .withDescription(
                             "Metric aggregator to use for busyTime metrics. This affects how true processing/output rate will be computed. Using max allows us to handle jobs with data skew more robustly, while avg may provide better stability when we know that the load distribution is even.");
 
+    public static final ConfigOption<Double> VERTEX_IDLE_INPUT_RATE_THRESHOLD =
+            autoScalerConfig("vertex.idle-input-rate-threshold")
+                    .doubleType()
+                    .defaultValue(0.01)
+                    .withFallbackKeys(oldOperatorConfigKey("vertex.idle-input-rate-threshold"))
+                    .withDescription(
+                            "Per-subtask input rate, in records per second averaged over the metric window, below which a vertex is treated as idle and its busy time based true processing rate is not trusted. Below this rate there are too few records per subtask to estimate a processing rate, while the aggregated busy time can still read close to saturated (with the default MAX aggregator a single briefly-busy subtask reports for the whole vertex). That combination makes the scale factor saturate the scale-up and scale-down clamps on alternating evaluations, so the vertex oscillates between min and max parallelism. Such vertices are treated the same as ones with an input rate of exactly zero. Set to 0 to restore the previous behaviour of only special-casing an exactly-zero rate.");
+
     public static final ConfigOption<List<String>> VERTEX_EXCLUDE_IDS =
             autoScalerConfig("vertex.exclude.ids")
                     .stringType()

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
@@ -427,7 +427,7 @@ public class ScalingMetricEvaluatorTest {
         assertEquals(
                 350,
                 ScalingMetricEvaluator.computeTrueProcessingRate(
-                        100, 35, metricHistory, source, conf));
+                        100, 35, metricHistory, source, conf, 1));
 
         // Set diff threshold to 10% -> outside threshold
         conf.set(AutoScalerOptions.OBSERVED_TRUE_PROCESSING_RATE_SWITCH_THRESHOLD, 0.1);
@@ -436,14 +436,14 @@ public class ScalingMetricEvaluatorTest {
         assertEquals(
                 300,
                 ScalingMetricEvaluator.computeTrueProcessingRate(
-                        100, 35, metricHistory, source, conf));
+                        100, 35, metricHistory, source, conf, 1));
 
         // Test that observed tpr min observations are respected. If less, use busy time
         conf.set(AutoScalerOptions.OBSERVED_TRUE_PROCESSING_RATE_MIN_OBSERVATIONS, 3);
         assertEquals(
                 350,
                 ScalingMetricEvaluator.computeTrueProcessingRate(
-                        100, 35, metricHistory, source, conf));
+                        100, 35, metricHistory, source, conf, 1));
     }
 
     @Test
@@ -456,22 +456,22 @@ public class ScalingMetricEvaluatorTest {
         assertEquals(
                 350.,
                 ScalingMetricEvaluator.computeTrueProcessingRate(
-                        100, 35, metricHistory, source, conf));
+                        100, 35, metricHistory, source, conf, 1));
 
         assertEquals(
                 Double.POSITIVE_INFINITY,
                 ScalingMetricEvaluator.computeTrueProcessingRate(
-                        0, 100, metricHistory, source, conf));
+                        0, 100, metricHistory, source, conf, 1));
 
         assertEquals(
                 Double.POSITIVE_INFINITY,
                 ScalingMetricEvaluator.computeTrueProcessingRate(
-                        0, 0, metricHistory, source, conf));
+                        0, 0, metricHistory, source, conf, 1));
 
         assertEquals(
                 Double.NaN,
                 ScalingMetricEvaluator.computeTrueProcessingRate(
-                        Double.NaN, Double.NaN, metricHistory, source, conf));
+                        Double.NaN, Double.NaN, metricHistory, source, conf, 1));
     }
 
     @Test
@@ -490,7 +490,7 @@ public class ScalingMetricEvaluatorTest {
         assertEquals(
                 300.,
                 ScalingMetricEvaluator.computeTrueProcessingRate(
-                        Double.NaN, 1., metricHistory, source, new Configuration()));
+                        Double.NaN, 1., metricHistory, source, new Configuration(), 1));
     }
 
     @Test
@@ -595,7 +595,85 @@ public class ScalingMetricEvaluatorTest {
                         inputRate,
                         new TreeMap<>(),
                         new JobVertexID(),
-                        new Configuration()));
+                        new Configuration(),
+                        1));
+    }
+
+    @Test
+    public void testIdleWideVertexIsNotScaledOnNoiseFloorTpr() {
+        // A processing-failure / dead-letter sink: 100 subtasks handling ~0.03 records per second
+        // between them, so 0.0003 records per subtask per second. Meanwhile a single subtask is
+        // briefly busy each window (checkpoint-aligned committer work) and with the default MAX
+        // aggregator that one subtask reports 1000 ms/s for the whole vertex.
+        var v = new JobVertexID();
+        var conf = new Configuration();
+        var metricHistory = new TreeMap<Instant, CollectedMetrics>();
+
+        // Without the guard the ratio would be 0.03 / 1.0 = 0.03 rec/s, a number built from two
+        // noise floors, which is what makes the scale factor saturate the clamps.
+        assertEquals(
+                Double.POSITIVE_INFINITY,
+                ScalingMetricEvaluator.computeTrueProcessingRate(
+                        1000., 0.03, metricHistory, v, conf, 100));
+
+        // Setting the threshold to 0 restores the previous behaviour.
+        conf.set(AutoScalerOptions.VERTEX_IDLE_INPUT_RATE_THRESHOLD, 0.0);
+        assertEquals(
+                0.03,
+                ScalingMetricEvaluator.computeTrueProcessingRate(
+                        1000., 0.03, metricHistory, v, conf, 100));
+    }
+
+    @Test
+    public void testSlowButSaturatedVertexIsStillScaled() {
+        // The case the guard must not break: parallelism 1, half a record per second, but each
+        // record takes ~2s so the single subtask is fully busy. 0.5 rec/subtask/s is 50x the
+        // default threshold, so this keeps its real true processing rate.
+        var v = new JobVertexID();
+        var conf = new Configuration();
+        var metricHistory = new TreeMap<Instant, CollectedMetrics>();
+
+        assertEquals(
+                0.5,
+                ScalingMetricEvaluator.computeTrueProcessingRate(
+                        1000., 0.5, metricHistory, v, conf, 1));
+
+        // The same total rate spread over 100 subtasks is idle by the same measure.
+        assertEquals(
+                Double.POSITIVE_INFINITY,
+                ScalingMetricEvaluator.computeTrueProcessingRate(
+                        1000., 0.5, metricHistory, v, conf, 100));
+    }
+
+    @Test
+    public void testIdleGuardIsSkippedForUnknownParallelism() {
+        // Parallelism is not always known. Rather than divide by zero, fall through to the
+        // existing behaviour.
+        var v = new JobVertexID();
+        var conf = new Configuration();
+        var metricHistory = new TreeMap<Instant, CollectedMetrics>();
+
+        assertEquals(
+                0.03,
+                ScalingMetricEvaluator.computeTrueProcessingRate(
+                        1000., 0.03, metricHistory, v, conf, 0));
+    }
+
+    @Test
+    public void testIdleGuardBoundary() {
+        var v = new JobVertexID();
+        var conf = new Configuration();
+        var metricHistory = new TreeMap<Instant, CollectedMetrics>();
+
+        // Exactly at the threshold is not idle, just below it is.
+        assertEquals(
+                0.1,
+                ScalingMetricEvaluator.computeTrueProcessingRate(
+                        1000., 0.1, metricHistory, v, conf, 10));
+        assertEquals(
+                Double.POSITIVE_INFINITY,
+                ScalingMetricEvaluator.computeTrueProcessingRate(
+                        1000., 0.09, metricHistory, v, conf, 10));
     }
 
     @Test


### PR DESCRIPTION
`computeTprFromBusyTime` returns infinite processing power when the input rate is *exactly* zero, so an idle vertex is never scaled up. There's no equivalent guard for a rate that's merely near zero, and that gap makes wide, almost-idle vertices oscillate between min and max parallelism forever.

## the bug

Two things have to line up.

1. A vertex processing a handful of records per metric window. True processing rate is `rate / busyTime`, and both sides are noise.
2. The default `MAX` busy-time aggregator, which reports the busiest single subtask as the busy time for the whole vertex.

On a vertex with 100 subtasks where one is briefly busy each window (a checkpoint-aligned sink committer, say), aggregated busy time reads close to 1000 ms/s while 99 subtasks do nothing. The scale factor then lands outside the clamps on alternating evaluations, so the vertex walks `1 + scale-up.max-factor` up and `1 - scale-down.max-factor` down and never converges.

We hit this on a Kafka dead-letter sink handling **0.03 records/sec**. It walked 4 → 16 → 64 → 105 and back down for four days straight, taking the whole job with it each step, because a rescale restarts every vertex. About 250 job restarts for a vertex doing two records a minute.

The clearest evidence is our own staging deployment of the same job. Its dead-letter sink sits at exactly 0.00 rec/s and has been rock stable at min parallelism the whole time. Production sits at 0.03 and flaps. That contrast is the bug in one line: the guard works at zero and not just above it.

## the fix

Extend the existing guard to a configurable **per-subtask** input rate, `job.autoscaler.vertex.idle-input-rate-threshold`, defaulting to 0.01 rec/sec/subtask. Below that there are too few records per subtask in a window to estimate a processing rate at all.

Per-subtask rather than per-vertex is the important part. A genuinely saturated low-throughput vertex must not be caught by this:

| | rec/s | parallelism | rec/s/subtask | verdict |
|---|---|---|---|---|
| slow but saturated | 0.5 | 1 | 0.5 | scaled normally, 50x threshold |
| dead-letter sink | 0.03 | 100 | 0.0003 | idle, 33x below threshold |

Set the option to `0` to restore the previous behaviour exactly.

## why this doesn't strand backlogged vertices

`selectTprMetric` already prefers `OBSERVED_TPR` over an infinite busy-time TPR, and observed TPR is sampled during catch-up. So a vertex that trips the guard *and* has real backlog still scales on its observed rate. Without backlog, the infinite TPR walks parallelism down to the minimum and holds it, which is exactly what an exactly-zero-rate vertex gets today.

## what I tried first, and why it isn't this

My first version keyed the guard on mean busy time per subtask, derived from `ACCUMULATED_BUSY_TIME`, on the theory that the real defect is `MAX` hiding how many subtasks are actually working. It's a better description of the problem, and it broke 34 existing tests.

The tests were right. Fixtures like `new IOMetrics(0, 0, 0)` drive `LOAD` directly and leave accumulated busy time pinned at zero, which made the guard fire for every vertex. That's not just a fixture quirk: it means the guard would depend on a second metric that can be absent or stuck at zero, and any deployment where accumulated busy time isn't reported properly would silently lose scale-up on every vertex. Strictly worse than the bug being fixed.

The rate-based version depends only on `rate` and `parallelism`, both already in hand at the call site, and is a straight generalization of the `rate == 0` line right above it.

## testing

- 183 tests pass in `flink-autoscaler`, up from 179 on `main` with 0 failures, so nothing regressed and 4 tests were added.
- New coverage: the wide idle vertex, the slow-but-saturated counterexample in both parallelism arrangements, unknown parallelism, and the threshold boundary.
- `spotless:check` and `checkstyle:check` clean. `auto_scaler_configuration.html` regenerated via the `generate-docs` profile.

Built and tested on JDK 17 (the repo requires 17; the CRD regeneration that the docs profile also triggers is pure quoting churn from a different Fabric8 version and has been left out).

## upstream

This is a bug in `apache/flink-kubernetes-operator`, not something we introduced. Worth taking upstream as a JIRA with the reproduction above once it's had some soak time here.
